### PR TITLE
Fix typo in image/jp2 MIME type

### DIFF
--- a/metadataguidelines.md
+++ b/metadataguidelines.md
@@ -327,7 +327,7 @@ Digitized other analog | A resource was created by digitizing an intermediate fo
 * application/pdf
 * image/tiff
 * image/jpeg
-* iamge/jp2
+* image/jp2
 * video/mp4
 * video/quicktime
 * video/MP2T


### PR DESCRIPTION
"image" was incorrectly spelled as "iamge"